### PR TITLE
Multiple inputs fix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 # Pas censé être là mais on sait jamais
 launched
 
-log
+log.log

--- a/.vscode/launch.json.default
+++ b/.vscode/launch.json.default
@@ -5,7 +5,7 @@
             "name": "Launch Web server interactive",
             "type": "node-terminal",
             "request": "launch",
-            "command": "python3 -i ${workspaceFolder}/src/server/main.py > log",
+            "command": "python3 -i ${workspaceFolder}/src/server/main.py",
             "cwd": "${workspaceFolder}/src",
             "env": {
                 "PYTHONPATH": "${workspaceFolder}/src/libs/"

--- a/src/libs/wsinter.py
+++ b/src/libs/wsinter.py
@@ -144,6 +144,8 @@ function faire(o){
         self.reponse_http(Inter._chemin_js, lambda c,p: (Inter._js.replace("_ws_port",str(self._ws_port),1),"js"))
 
         self._threads_fils=[]
+        
+        self.pressed_keys = {}
 
     def gestionnaire(self, message:str,handler:callable,nonbloc:bool=False):
         """
@@ -707,9 +709,16 @@ function faire(o){
             self._handlers["_mh"][0](data[0][3],data[1])
         elif data[0]=="**KD**":
 #            print("KD event")
+            # On veut pas de repetition dans les touches, la premiere n'est jamais repetee donc aucun probleme
+            if data[1][6]:
+                for pressed_key in self.pressed_keys.values():
+                    self._process(pressed_key)
+                return
+            self.pressed_keys[data[1][5]] = chaine
             self._handlers["_kh"][0](data[0][3],data[1])
         elif data[0]=="**KU**":
 #            print("KU event")
+            self.pressed_keys.pop(data[1][5], None)
             self._handlers["_kh"][0](data[0][3],data[1])
         elif data[0] in self._handlers and self._handlers[data[0]] is not None:
             handler,nonbloc = self._handlers[data[0]]

--- a/src/libs/wsinter.py
+++ b/src/libs/wsinter.py
@@ -689,6 +689,7 @@ function faire(o){
                 """
         self._push([{'id':'_new_script','tagName':'script','data':{'innerHTML':code}}])
 
+    pressed_keys = None
     def _process(self,chaine:str):
         """
         chaine reçue via websocket
@@ -698,6 +699,9 @@ function faire(o){
             data = json.loads(chaine)
         except:
             print("Erreur à l'analyse des données")
+            
+        if self.pressed_keys == None:
+            self.pressed_keys = dict()
         
         if data[0]=="**MD**":
 #            print("MD event")
@@ -707,9 +711,16 @@ function faire(o){
             self._handlers["_mh"][0](data[0][3],data[1])
         elif data[0]=="**KD**":
 #            print("KD event")
-            self._handlers["_kh"][0](data[0][3],data[1])
+            if data[1][6]:
+                self.pressed_keys[data[1][5]] = data[1]
+                for key in self.pressed_keys.values():
+                    self._handlers["_kh"][0]("D",key)
+            else:
+                self._handlers["_kh"][0](data[0][3],data[1])
         elif data[0]=="**KU**":
 #            print("KU event")
+            if data[1][5] in self.pressed_keys.keys():
+                del self.pressed_keys[data[1][5]]
             self._handlers["_kh"][0](data[0][3],data[1])
         elif data[0] in self._handlers and self._handlers[data[0]] is not None:
             handler,nonbloc = self._handlers[data[0]]

--- a/src/libs/wsinter.py
+++ b/src/libs/wsinter.py
@@ -689,7 +689,6 @@ function faire(o){
                 """
         self._push([{'id':'_new_script','tagName':'script','data':{'innerHTML':code}}])
 
-    pressed_keys = None
     def _process(self,chaine:str):
         """
         chaine reçue via websocket
@@ -699,9 +698,6 @@ function faire(o){
             data = json.loads(chaine)
         except:
             print("Erreur à l'analyse des données")
-            
-        if self.pressed_keys == None:
-            self.pressed_keys = dict()
         
         if data[0]=="**MD**":
 #            print("MD event")
@@ -711,16 +707,9 @@ function faire(o){
             self._handlers["_mh"][0](data[0][3],data[1])
         elif data[0]=="**KD**":
 #            print("KD event")
-            if data[1][6]:
-                self.pressed_keys[data[1][5]] = data[1]
-                for key in self.pressed_keys.values():
-                    self._handlers["_kh"][0]("D",key)
-            else:
-                self._handlers["_kh"][0](data[0][3],data[1])
+            self._handlers["_kh"][0](data[0][3],data[1])
         elif data[0]=="**KU**":
 #            print("KU event")
-            if data[1][5] in self.pressed_keys.keys():
-                del self.pressed_keys[data[1][5]]
             self._handlers["_kh"][0](data[0][3],data[1])
         elif data[0] in self._handlers and self._handlers[data[0]] is not None:
             handler,nonbloc = self._handlers[data[0]]

--- a/src/libs/wsinter.py
+++ b/src/libs/wsinter.py
@@ -145,7 +145,7 @@ function faire(o){
 
         self._threads_fils=[]
         
-        self.pressed_keys = {}
+        self.pressed_keys = []
 
     def gestionnaire(self, message:str,handler:callable,nonbloc:bool=False):
         """
@@ -311,6 +311,12 @@ function faire(o){
           - associées à un contenu de type str : htm, html, css, js, csv, json, svg, html, xml
         """ 
         self._htresponse[req]=gen
+        
+    def touches(self):
+        """
+        Renvoie une liste de touches appuyees en cet instant
+        """
+        return self.pressed_keys
 
     def servir(self,ip : str = '127.0.0.1', port : int = 5080, max_conn : int = -1) -> None:
         """
@@ -710,15 +716,13 @@ function faire(o){
         elif data[0]=="**KD**":
 #            print("KD event")
             # On veut pas de repetition dans les touches, la premiere n'est jamais repetee donc aucun probleme
-            if data[1][6]:
-                for pressed_key in self.pressed_keys.values():
-                    self._process(pressed_key)
-                return
-            self.pressed_keys[data[1][5]] = chaine
+            if not data[1][6]:
+                # Logiquement, pas de doublons, car quand on relache la touche, l'element est supprime
+                self.pressed_keys.append(data[1][5])
             self._handlers["_kh"][0](data[0][3],data[1])
         elif data[0]=="**KU**":
 #            print("KU event")
-            self.pressed_keys.pop(data[1][5], None)
+            self.pressed_keys.remove(data[1][5])
             self._handlers["_kh"][0](data[0][3],data[1])
         elif data[0] in self._handlers and self._handlers[data[0]] is not None:
             handler,nonbloc = self._handlers[data[0]]

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -1,16 +1,16 @@
+import os # remove
+import time # time, sleep
+import threading # Threading
+
 from player import Player
-from web.main_web import start
+import web.main_web # start
 import web.inputs.keyboard
 import web.inputs.mouse
-import os
 
-web_manager = None
+game = None
 
 def main():
-    """
-    Point d'entree du programme quand on lance le serveur
-    """
-    global web_manager
+    global game
     
     try:
         lock = open("launched", "x")
@@ -20,25 +20,66 @@ def main():
         exit(0)
         return
     
-    web_manager = start()
+    game = Game()
     
-    # Gestionnaires inputs
-    web_manager.gestionnaire_clavier(web.inputs.keyboard.handle_input)
-    web_manager.gestionnaire_souris(web.inputs.mouse.handle_input)
-        
-    player = Player((50, 50))
-    web.inputs.keyboard.add_event(player.move_input, "D", ["KeyW", "KeyA", "KeyS", "KeyD"])
-    web.inputs.mouse.add_event(player.move_random, "U", [player.id])
-
 def stop():
-    """
-    Fonction a appeler pour fermer **correctement** le serveur
-    """
-    web_manager.stop(fermer=False)
+    global game
+    game.stop()
     
     os.remove("launched")
-    
     exit(0)
+
+class Game:
+    def __init__(self):
+        """
+        Point d'entree du programme quand on lance le serveur
+        """        
+        self.web_manager = web.main_web.start()
+        
+        # Gestionnaires inputs
+        self.web_manager.gestionnaire_clavier(web.inputs.keyboard.handle_input)
+        self.web_manager.gestionnaire_souris(web.inputs.mouse.handle_input)
+            
+        self.player = Player((50, 50))
+        #web.inputs.keyboard.add_event(player.move_input, "D", ["KeyW", "KeyA", "KeyS", "KeyD"])
+        # Tmp, for testing purposes
+        web.inputs.mouse.add_event(self.player.move_random, "U", [self.player.id])
+        
+        # On lance la boucle principale
+        self.loop_thread = threading.Thread(target=self.loop)
+        self.loop_thread.start()
+
+    def loop(self):
+        """
+        Contient la boucle principale
+        
+        On vise 60 images par secondes, donc 60 iterations par seconde, faire plus serait consommer beaucoup de ressources pour pas grand chose
+        
+        Poour la physique on pourrait meme viser 30 iterations par seconde
+        
+        Ainsi on conditionne le temps
+        """
+        self.do_loop = True
+        last_loop_time = time.time()
+        
+        while self.do_loop:
+            delta_time = time.time() - last_loop_time
+            # 1 / 60 ~= 0.017, on s'embete pas à faire le calcul tout le temps, on pourrait limite stocker dans une variable mais pas tres utile non plus
+            if delta_time < 0.017:
+                continue
+            
+            keys = self.web_manager.touches()
+            self.player.update(delta_time, keys)
+            
+            last_loop_time = time.time()
+
+    def stop(self):
+        """
+        Fonction a appeler pour fermer **correctement** le serveur
+        """
+        self.do_loop = False
+        self.loop_thread.join()
+        self.web_manager.stop(fermer=False)
     
 # On verifie que le programme n'est pas importe mais bien lance
 if __name__ == "__main__":

--- a/src/server/player.py
+++ b/src/server/player.py
@@ -3,7 +3,7 @@ from random import randint
 
 IMG_PATH = "assets/spritesheets/blonde_man/blonde_man_001.png"
 IMG_SIZE = 32
-MOVE_AMOUNT = 2
+MOVE_AMOUNT = 10
 MIN_X = 0
 MIN_Y = 0
 
@@ -16,6 +16,62 @@ class Player:
         self.width = IMG_SIZE
         self.height = IMG_SIZE
         self.id = add_image(IMG_PATH, (self.x, self.y))
+        
+        self.movement_vector = [0, 0]
+        # Changés par le sol / environnement
+        self.max_movement = (1, 1)
+        self.friction_coef = 0.8
+        
+    def move_range(self, movement: tuple):
+        self.movement_vector[0] += movement[0]
+        if self.movement_vector[0] < 0 and self.movement_vector[0] < -1 * self.max_movement[0]:
+            self.movement_vector[0] = -1 * self.max_movement[0]
+        if self.movement_vector[0] > 0 and self.movement_vector[0] > self.max_movement[0]:
+            self.movement_vector[0] = self.max_movement[0]
+
+        self.movement_vector[1] += movement[1]
+        if self.movement_vector[1] < 0 and self.movement_vector[1] < -1 * self.max_movement[1]:
+            self.movement_vector[1] = -1 * self.max_movement[1]
+        if self.movement_vector[1] > 0 and self.movement_vector[1] > self.max_movement[1]:
+            self.movement_vector[1] = self.max_movement[1]
+            
+    def update(self, delta_time: float, keys: list):
+        """
+        delta_time est le temps en secondes depuis la derniere update, il sert de coefficient sur la vitesse de deplacement notamment
+        """
+        # On applique le vecteur mouvement sur la position, en tenant compte des inputs et de la friction s'il n'y a pas d'inputs
+        # Tant que la friction n'est pas supérieure à 1, on a pas besoin de vérifier avec le vecteur max_movement, car le mouvement diminue,
+        # Mais si dans le futur il y a changement sur ca il faudra check tout le temps
+        movement = self._process_keys(keys)
+        self.movement_vector[0] *= self.friction_coef
+        self.movement_vector[1] *= self.friction_coef
+        if movement != [0, 0]:
+            movement[0] *= delta_time
+            movement[1] *= delta_time
+            self.move_range(movement)
+            
+        self.move(self.movement_vector)
+        self.render()
+        
+    def _process_keys(self, keys: list) -> list:
+        """
+        keys -- liste de touches appuyees, identifiees par leur code
+        
+        Renvoie un tuple definissant le mouvement selon le mouvement
+        """
+        move = [0, 0]
+        for key in keys:
+            match key:
+                case "KeyW":
+                    move[1] -= MOVE_AMOUNT
+                case "KeyA":
+                    move[0] -= MOVE_AMOUNT
+                case "KeyS":
+                    move[1] += MOVE_AMOUNT
+                case "KeyD":
+                    move[0] += MOVE_AMOUNT
+        return move
+
         
     def move(self, movement: tuple):
         """
@@ -35,8 +91,6 @@ class Player:
         self.y = min(self.y, window_size[1] - self.height)
         self.y = max(MIN_Y, self.y)
         
-        self.render()
-        
     def move_input(self, key):
         """
         Recupere l'evenement d'appui de touche pour bouger le joueur
@@ -54,6 +108,7 @@ class Player:
     def move_random(self, button):
         if button[1] == 0:
             self.move((randint(-100, 100), randint(-100, 100)))
+        self.render()
         
     def render(self):
         change_dimensions(self.id, (self.x, self.y))


### PR DESCRIPTION
# Problème 

Fixe le bogue où l'appui de plusieurs de touches en même temps ne répertorie en réalité que l'appui d'une touche répétée, ainsi un gestionnaires d'événements clavier qui modifieraitt la position du joueur dès qu'il y a une entrée clavier n'est mas viable
Voir #1 

# Solution

Pour pallier à ce problème, on créer une liste qui contient toutes les touches qui sont actuellement enfoncées, ainsi on change cette liste au premier appui d'une touche (et donc sans compter si l'attribut repeat est à True) et au moment où la touche est relâchée. Cette modification est faite dans `wsinter.py` pour plus de simplicité, même s'il est possible de modifier `keyboard.py` par exemple.
Une boucle principale, tournant sur un autre Thread (au même titre que wss_instance et http_instance dans `wsinter.py`). Ainsi à chaque itération de la boucle on regarde quelles touches sont appuyées pour en déduire le mouvement du joueur. À noter que la boucle est limitée à 60 itérations par seconde afin d'éviter le trop gros nombre de calculs*, et utiliser 100% de son processeur par la même occasion...*

Closes #1